### PR TITLE
ServiceCard 프로젝트 없는 상황의 null 처리 코드 수정

### DIFF
--- a/src/containers/Feed/components/cards/ServiceCard.tsx
+++ b/src/containers/Feed/components/cards/ServiceCard.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { AiFillCodeSandboxCircle } from 'react-icons/ai'
 
 const ServiceCard: React.FC = () => {
-  if (!CONFIG.projects) return null
+  if (!CONFIG.projects.length) return null
   return (
     <>
       <div className="p-1 mb-3 dark:text-white">🌟 Service</div>


### PR DESCRIPTION
morethan-log.config.js 파일의 projects array의 길이가 0일 때 아래의
`if (!CONFIG.projects) return null`
코드가 정상적으로 동작하지 않아 배열의 길이 여부를 정상적으로 확인할 수 있게 수정 하였습니다.

