### PR TITLE
[Fix] notion-toggle 내부 element overflow 해결

### DIFF
--- a/src/styles/notion.css
+++ b/src/styles/notion.css
@@ -13,6 +13,10 @@
   @apply my-1;
 }
 
+.notion-toggle{
+  @apply w-full !important;
+}
+
 .notion-list li {
   @apply py-0;
 }

--- a/src/styles/notion.css
+++ b/src/styles/notion.css
@@ -14,7 +14,7 @@
 }
 
 .notion-toggle{
-  @apply w-full !important;
+  @apply w-full;
 }
 
 .notion-list li {


### PR DESCRIPTION
.notion-toggle style에 width가 정의되어 있지 않아 아래 element 에서 parent width를 찾지 못하는 이슈같습니다. 확인 부탁드려요.