### PR TITLE
[FIX] sync cusdis theme with blog theme value

### DIFF
--- a/src/components/Cusdis.tsx
+++ b/src/components/Cusdis.tsx
@@ -1,5 +1,6 @@
 import { cusdis, link } from "site.config"
 import { ReactCusdis } from "react-cusdis"
+import { useCallback, useEffect, useState } from "react"
 
 type Props = {
   id: string
@@ -8,17 +9,44 @@ type Props = {
 }
 
 const Cusdis: React.FC<Props> = ({ id, slug, title }) => {
+  const [value, setValue] = useState(0)
+
+  const onDocumentElementChange = useCallback(() => {
+    setValue((value) => value + 1)
+  }, [])
+
+  useEffect(() => {
+    const changesObserver = new MutationObserver(
+      (mutations: MutationRecord[]) => {
+        mutations.forEach((mutation: MutationRecord) => {
+          onDocumentElementChange()
+        })
+      }
+    )
+
+    changesObserver.observe(document.documentElement, {
+      attributeFilter: ["class"],
+    })
+
+    return () => {
+      changesObserver.disconnect()
+    }
+  }, [onDocumentElementChange])
+
   return (
     <>
-      <div id="comments" className="mt-4">
+      <div id="comments" className="mt-10">
         <ReactCusdis
+          key={value}
           attrs={{
             host: cusdis.config.host,
             appId: cusdis.config.appid,
             pageId: id,
             pageTitle: title,
             pageUrl: `${link}/${slug}`,
-            theme: "auto",
+            theme: document.documentElement.classList.contains("dark")
+              ? "dark"
+              : "light",
           }}
         />
       </div>


### PR DESCRIPTION
<!-- 1. Verify PR Title -->
<!-- PR Title example: `[FIX | REFACTOR | FEAT | UPDATE | DOCUMENTATION] repair the page layout` -->

<!-- 2. Provide Description of the changes -->

## Description

<!--
- provide a description of the changes made. If there are some pending TODOs, include them there as well.
- Any guidance for reviewers to better understand the changes.
- Any visuals (screenshots, screen recordings) that can give assurance that the changes are safe to merge.
-->

- Resolve the problem that Cusdis's theme is different from the blog theme.

notes:
- It is difficult to change Cusdis color because theme customizing is not supported in Cusdis SDK, and the background color is automatically specified by `color-scheme`.
  - If you want to change the color, I preferred to change the `/js/cusdis.css` file inside the cusdis. (only can self-host version)

<!-- 3. Add link to the Github Issue for which these changes are made -->

## Related tickets

https://github.com/morethanmin/morethan-log/issues/95

<!-- 4. Make sure the following actions are checked before finalising your PR -->

## PR Checklist

- [x] I have read the [Contributing Guide](./docs/CONTRIBUTING.md)
- [x] I have written documents and tests, if needed.
