### PR TITLE
FIX: fix table notion overflow on mobile

### DIFF
--- a/src/styles/notion.css
+++ b/src/styles/notion.css
@@ -72,6 +72,7 @@ pre[class*="language-"] {
 .notion-page {
   @apply w-auto;
   @apply px-0;
+  @apply overflow-scroll;
 }
 .notion-quote {
   padding: 0.2em 0.9em;


### PR DESCRIPTION
## Description
When there is table from notion content, it will overflow and mobile layout look out of place. So I add overflow-scroll style on notion-page class
![Screenshot 2566-03-26 at 22 04 10](https://user-images.githubusercontent.com/39083566/227784705-c705b139-95da-4195-8162-2905c88fca34.png)

## PR Checklist

- [x] I have read the [Contributing Guide](./docs/CONTRIBUTING.md)
- [x] I have written documents and tests, if needed.
