### PR TITLE
Fix: grey scroll bar on detail page

### DIFF
--- a/src/styles/notion.css
+++ b/src/styles/notion.css
@@ -72,7 +72,7 @@ pre[class*="language-"] {
 .notion-page {
   @apply w-auto;
   @apply px-0;
-  @apply overflow-scroll;
+  @apply overflow-auto;
 }
 .notion-quote {
   padding: 0.2em 0.9em;


### PR DESCRIPTION
## Description
Look like my previos fix make this happen. There is a grey scroll bar on all detail page. So here another pull request.
![Screenshot 2566-03-28 at 11 56 10](https://user-images.githubusercontent.com/39083566/228132535-74422ded-24e1-42f2-b3f3-7a4b906a27ce.png)

## PR Checklist

- [x] I have read the [Contributing Guide](./docs/CONTRIBUTING.md)
- [x] I have written documents and tests, if needed.
