### PR TITLE
Fix:google analytics not working even though I have add ga id correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Next.js static blog using Notion as a Content Management System (CMS). Supports 
 6. Deploy on Vercel, with the following environment variables.
 
    - `NOTION_PAGE_ID` (Required): The Notion page Id got from the Share to Web URL.
-   - `GOOGLE_MEASUREMENT_ID` : For Google analytics Plugin.
-   - `GOOGLE_SITE_VERIFICATION` : For Google search console Plugin.
+   - `NEXT_PUBLIC_GOOGLE_MEASUREMENT_ID` : For Google analytics Plugin.
+   - `NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION` : For Google search console Plugin.
 
 ## Contributing
 

--- a/site.config.js
+++ b/site.config.js
@@ -41,13 +41,13 @@ const CONFIG = {
   googleAnalytics: {
     enable: false,
     config: {
-      measurementId: process.env.GOOGLE_MEASUREMENT_ID || "",
+      measurementId: process.env.NEXT_PUBLIC_GOOGLE_MEASUREMENT_ID || "",
     },
   },
   googleSearchConsole: {
     enable: false,
     config: {
-      siteVerification: process.env.GOOGLE_SITE_VERIFICATION || "",
+      siteVerification: process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION || "",
     },
   },
   utterances: {


### PR DESCRIPTION
## Description
I have enable GA and add GOOGLE_MEASUREMENT_ID environment variable on vercel or .env file but it's not working. The script after build did not have google id I put.
![Screenshot 2566-03-29 at 10 18 50](https://user-images.githubusercontent.com/39083566/228420150-4d240b5b-0764-4ff7-8314-6c90671386a2.png)

After some research, when next build it will not see normal environment and only see NEXT_PUBLIC_{***} environment field name. So I rename the following GOOGLE_MEASUREMENT_ID, GOOGLE_SITE_VERIFICATION to ``NEXT_PUBLIC_GOOGLE_MEASUREMENT_ID, NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION``.
Both are used in next server side rendering.


## PR Checklist

- [x] I have read the [Contributing Guide](./docs/CONTRIBUTING.md)
- [x] I have written documents and tests, if needed.
