### PR TITLE
[FEAT] react notion x 및 NotionRender 업데이트

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "react-cusdis": "^2.1.3",
     "react-dom": "^17.0.2",
     "react-icons": "^4.4.0",
-    "react-notion-x": "^4.11.0"
+    "react-notion-x": "^6.16.0"
   },
   "devDependencies": {
     "@types/gtag.js": "^0.0.12",

--- a/src/containers/Detail/components/PageDetail/index.tsx
+++ b/src/containers/Detail/components/PageDetail/index.tsx
@@ -1,12 +1,32 @@
-import {
-  NotionRenderer,
-  Equation,
-  Code,
-  Collection,
-  CollectionRow,
-} from "react-notion-x"
+import { NotionRenderer } from "react-notion-x"
 import { TPost } from "@/src/types"
 import React from "react"
+import dynamic from "next/dynamic"
+import Link from "next/link"
+import Image from "next/image"
+const Code = dynamic(() =>
+  import("react-notion-x/build/third-party/code").then((m) => m.Code)
+)
+const Collection = dynamic(() =>
+  import("react-notion-x/build/third-party/collection").then(
+    (m) => m.Collection
+  )
+)
+const Equation = dynamic(() =>
+  import("react-notion-x/build/third-party/equation").then((m) => m.Equation)
+)
+const Pdf = dynamic(
+  () => import("react-notion-x/build/third-party/pdf").then((m) => m.Pdf),
+  {
+    ssr: false,
+  }
+)
+const Modal = dynamic(
+  () => import("react-notion-x/build/third-party/modal").then((m) => m.Modal),
+  {
+    ssr: false,
+  }
+)
 
 const mapPageUrl = (id: string) => {
   return "https://www.notion.so/" + id.replace(/-/g, "")
@@ -23,10 +43,13 @@ const PageDetail: React.FC<Props> = ({ blockMap, data }) => {
       <NotionRenderer
         recordMap={blockMap}
         components={{
-          equation: Equation,
-          code: Code,
-          collection: Collection,
-          collectionRow: CollectionRow,
+          Code,
+          Collection,
+          Equation,
+          Modal,
+          Pdf,
+          nextImage: Image,
+          nextLink: Link,
         }}
         mapPageUrl={mapPageUrl}
       />

--- a/src/containers/Detail/components/PostDetail/index.tsx
+++ b/src/containers/Detail/components/PostDetail/index.tsx
@@ -1,16 +1,36 @@
-import {
-  NotionRenderer,
-  Equation,
-  Code,
-  Collection,
-  CollectionRow,
-} from "react-notion-x"
+import { NotionRenderer } from "react-notion-x"
+import dynamic from "next/dynamic"
 import { TPost } from "@/src/types"
 import React from "react"
 import PostHeader from "./PostHeader"
 import Footer from "./PostFooter"
 import CommentBox from "./CommentBox"
 import Category from "@components/Category"
+import Image from "next/image"
+import Link from "next/link"
+const Code = dynamic(() =>
+  import("react-notion-x/build/third-party/code").then((m) => m.Code)
+)
+const Collection = dynamic(() =>
+  import("react-notion-x/build/third-party/collection").then(
+    (m) => m.Collection
+  )
+)
+const Equation = dynamic(() =>
+  import("react-notion-x/build/third-party/equation").then((m) => m.Equation)
+)
+const Pdf = dynamic(
+  () => import("react-notion-x/build/third-party/pdf").then((m) => m.Pdf),
+  {
+    ssr: false,
+  }
+)
+const Modal = dynamic(
+  () => import("react-notion-x/build/third-party/modal").then((m) => m.Modal),
+  {
+    ssr: false,
+  }
+)
 
 const mapPageUrl = (id: string) => {
   return "https://www.notion.so/" + id.replace(/-/g, "")
@@ -43,10 +63,13 @@ const PostDetail: React.FC<Props> = ({ blockMap, data }) => {
             <NotionRenderer
               recordMap={blockMap}
               components={{
-                equation: Equation,
-                code: Code,
-                collection: Collection,
-                collectionRow: CollectionRow,
+                Code,
+                Collection,
+                Equation,
+                Modal,
+                Pdf,
+                nextImage: Image,
+                nextLink: Link,
               }}
               mapPageUrl={mapPageUrl}
             />

--- a/src/libs/apis/getPosts.ts
+++ b/src/libs/apis/getPosts.ts
@@ -6,11 +6,24 @@ import getAllPageIds from "@libs/utils/notion/getAllPageIds"
 import getPageProperties from "@libs/utils/notion/getPageProperties"
 import { TPosts } from "@customTypes/index"
 
+declare global {
+  var notionDatas: { TPosts: TPosts; savedDate: Date }
+}
+
 /**
  * @param {{ includePages: boolean }} - false: posts only / true: include pages
  */
 
 export async function getPosts() {
+  if (global?.notionDatas) {
+    const saved = global.notionDatas.savedDate
+    const now = new Date()
+    const diff = (now.getTime() - saved.getTime()) / 1000
+    if (diff < 60 * 60) {
+      return global.notionDatas.TPosts
+    }
+  }
+
   let id = CONFIG.notionConfig.pageId as string
   const api = new NotionAPI()
 
@@ -51,6 +64,8 @@ export async function getPosts() {
       const dateB: any = new Date(b?.date?.start_date || b.createdTime)
       return dateB - dateA
     })
+
+    global.notionDatas = { TPosts: data, savedDate: new Date() }
 
     return data as TPosts
   }


### PR DESCRIPTION
## Description

### 📌 개발환경에서 getPosts()가 자주 호출되는 것을 피하고자했습니다.
- getPosts()에서 전역변수를 활용하여 메인 페이지는 추가 요청없이 캐싱(?)되도록 하였습니다.
- 어차피 getStaticPaths() 때문에 상세페이지에서는 거의 계속 호출되지만...

### 📌 react-notion-x 를 업데이트 하였습니다.
- 이미지가 캐싱이 안되어 찾아보니, 우선 next/image가 notionrender 에서 적용이 안되고 있었습니다. 
- 해당 문제를 해결하기 위해 해당 패키지를 업데이트하고, 추가적으로 dynamic을 통해 components를 import하도록 하였습니다.
- 해당 사항 적용을 통해 캐싱이 되는 것을 확인하였습니다.
<img width="300" alt="스크린샷 2023-04-26 오후 10 47 24" src="https://user-images.githubusercontent.com/29947261/234595766-db2d1d8e-1ca8-41fc-bc17-9a92224ce8ae.png">

## Related tickets
-

## PR Checklist

- [x] I have read the [Contributing Guide](./docs/CONTRIBUTING.md)
- [x] I have written documents and tests, if needed.
