### PR TITLE
[feat]: ✨ add table style

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,6 +2,7 @@ import { AppPropsWithLayout } from "../types"
 import { Hydrate, QueryClientProvider } from "@tanstack/react-query"
 import { RootLayout } from "src/layouts"
 import { queryClient } from "src/libs/react-query"
+import "src/styles/table.css"
 
 function App({ Component, pageProps }: AppPropsWithLayout) {
   const getLayout = Component.getLayout || ((page) => page)

--- a/src/styles/table.css
+++ b/src/styles/table.css
@@ -1,0 +1,44 @@
+.notion-table-of-contents {
+  position: fixed;
+  right: -75%;
+  top: 80px;
+  display: flex;
+  flex-direction: column;
+}
+
+@media screen and (max-width: 1800px) {
+  .notion-table-of-contents {
+    right: -80%;
+  }
+}
+
+@media screen and (max-width: 1500px) {
+  .notion-table-of-contents {
+    position: static;
+  }
+}
+
+.notion-table-of-contents a {
+  padding: 0;
+  margin-bottom: 10px;
+}
+
+.notion-table-of-contents a:hover {
+  background: none;
+}
+
+.notion-table-of-contents span {
+  padding: 2px 2px;
+  line-height: 1.3;
+  background: linear-gradient(
+    to right,
+    rgba(255, 255, 255, 0) 50%,
+    var(--bg-color-0) 50%
+  );
+  background-size: 200%;
+  transition: 0.35s;
+}
+
+.notion-table-of-contents span:hover {
+  background-position: -100% 0;
+}


### PR DESCRIPTION
## Description


An intuitive UI was provided when the user added a table of contents:
<img width="591" alt="스크린샷 2023-11-06 오후 3 04 30" src="https://github.com/morethanmin/morethan-log/assets/80191860/122d4a57-8a4f-41ec-866d-ab6719584e92">

If the viewport is less than 1,500px, it returns to its original position:
<img width="593" alt="스크린샷 2023-11-06 오후 3 04 50" src="https://github.com/morethanmin/morethan-log/assets/80191860/fd401665-61aa-42ea-8771-543b66a3498b">

The following changes were made to add this function:
1. Create a `.css` file and add styling to the `.notion-table-of-contents` class
2. Import css file from `_app.tsx`

I've been using this feature on my branch for about 3 months, so it would be great to apply it to that branch too! 
It's already being applied on my site. If you want to see it in person, it would be a good idea to access the link.

**https://sion-log.vercel.app/next-14**

## PR Checklist

- [ ] I have read the [Contributing Guide](./docs/CONTRIBUTING.md)
- [ ] I have written documents and tests, if needed.
