### PR TITLE
[feat, refactor]: add eslint import order rules, refactor import order

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,48 @@
 {
-  "extends": ["next/core-web-vitals"]
+  "extends": ["next/core-web-vitals"],
+  "plugins": ["import"],
+  "rules": {
+    "sort-imports": [
+      "error",
+      {
+        "ignoreCase": true,
+        "ignoreDeclarationSort": true,
+        "ignoreMemberSort": false,
+        "allowSeparatedGroups": true
+      }
+    ],
+    "import/order": [
+      "error",
+      {
+        "newlines-between": "always",
+        "groups": [
+          ["builtin", "external"],
+          "internal",
+          "parent",
+          "sibling",
+          "index"
+        ],
+        "pathGroups": [
+          {
+            "pattern": "next",
+            "group": "builtin",
+            "position": "before"
+          },
+          {
+            "pattern": "react",
+            "group": "builtin"
+          },
+          {
+            "pattern": "src/**",
+            "group": "internal"
+          }
+        ],
+        "pathGroupsExcludedImportTypes": ["next", "next/app"],
+        "alphabetize": {
+          "order": "asc",
+          "caseInsensitive": true
+        }
+      }
+    ]
+  }
 }

--- a/src/apis/notion-client/getPosts.ts
+++ b/src/apis/notion-client/getPosts.ts
@@ -1,10 +1,9 @@
-import { CONFIG } from "site.config"
 import { NotionAPI } from "notion-client"
 import { idToUuid } from "notion-utils"
 
-import getAllPageIds from "src/libs/utils/notion/getAllPageIds"
-import getPageProperties from "src/libs/utils/notion/getPageProperties"
-import { TPosts } from "src/types"
+import { getAllPageIds, getPageProperties } from "@/libs/utils/notion"
+import { TPosts } from "@/types"
+import { CONFIG } from "site.config"
 
 /**
  * @param {{ includePages: boolean }} - false: posts only / true: include pages

--- a/src/components/Category/index.tsx
+++ b/src/components/Category/index.tsx
@@ -1,8 +1,10 @@
+import styled from "@emotion/styled"
 import { useRouter } from "next/router"
 import React from "react"
+
+import { colors } from "@/styles"
+
 import { COLOR_SET } from "./constants"
-import styled from "@emotion/styled"
-import { colors } from "src/styles"
 
 export const getColorClassByName = (name: string): string => {
   try {

--- a/src/components/Emoji.tsx
+++ b/src/components/Emoji.tsx
@@ -1,5 +1,5 @@
-import React, { ReactNode } from "react"
 import { Noto_Color_Emoji } from "next/font/google"
+import { ReactNode } from "react"
 
 const notoColorEmoji = Noto_Color_Emoji({
   weight: ["400"],

--- a/src/components/MetaConfig/index.tsx
+++ b/src/components/MetaConfig/index.tsx
@@ -1,5 +1,6 @@
-import { CONFIG } from "site.config"
 import Head from "next/head"
+
+import { CONFIG } from "site.config"
 
 export type MetaConfigProps = {
   title: string

--- a/src/hooks/useCategoriesQuery.ts
+++ b/src/hooks/useCategoriesQuery.ts
@@ -1,6 +1,7 @@
-import { DEFAULT_CATEGORY } from "src/constants"
+import { DEFAULT_CATEGORY } from "@/constants"
+import { getAllSelectItemsFromPosts } from "@/libs/utils/notion"
+
 import usePostsQuery from "./usePostsQuery"
-import { getAllSelectItemsFromPosts } from "src/libs/utils/notion"
 
 export const useCategoriesQuery = () => {
   const posts = usePostsQuery()

--- a/src/hooks/useDropdown.ts
+++ b/src/hooks/useDropdown.ts
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react'
+import React, { useRef, useState } from "react"
 
 type useDropdownType = () => [
   React.RefObject<HTMLDivElement>,
@@ -7,7 +7,7 @@ type useDropdownType = () => [
 ]
 
 function assertIsNode(e: EventTarget | null): asserts e is Node {
-  if (!e || !('nodeType' in e)) {
+  if (!e || !("nodeType" in e)) {
     throw new Error(`Node expected`)
   }
 }
@@ -26,7 +26,7 @@ const useDropdown: useDropdownType = () => {
 
   const onOpenBtn = () => {
     setIsDropdownOpened(true)
-    window.addEventListener('click', handleClick)
+    window.addEventListener("click", handleClick)
   }
 
   return [menuRef, isDropdownOpened, onOpenBtn]

--- a/src/hooks/usePostQuery.ts
+++ b/src/hooks/usePostQuery.ts
@@ -1,7 +1,8 @@
 import { useQuery } from "@tanstack/react-query"
 import { useRouter } from "next/router"
-import { queryKey } from "src/constants/queryKey"
-import { PostDetail } from "src/types"
+
+import { queryKey } from "@/constants/queryKey"
+import { PostDetail } from "@/types"
 
 const usePostQuery = () => {
   const router = useRouter()

--- a/src/hooks/usePostsQuery.ts
+++ b/src/hooks/usePostsQuery.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query"
-import { queryKey } from "src/constants/queryKey"
-import { TPost } from "src/types"
+
+import { queryKey } from "@/constants/queryKey"
+import { TPost } from "@/types"
 
 const usePostsQuery = () => {
   const { data } = useQuery({

--- a/src/hooks/useScheme.ts
+++ b/src/hooks/useScheme.ts
@@ -1,7 +1,8 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { getCookie, setCookie } from "cookies-next"
 import { useEffect } from "react"
-import { queryKey } from "src/constants/queryKey"
+
+import { queryKey } from "@/constants/queryKey"
 
 type Scheme = "light" | "dark"
 type SetScheme = (scheme: Scheme) => void

--- a/src/hooks/useTagsQuery.ts
+++ b/src/hooks/useTagsQuery.ts
@@ -1,5 +1,6 @@
+import { getAllSelectItemsFromPosts } from "@/libs/utils/notion"
+
 import usePostsQuery from "./usePostsQuery"
-import { getAllSelectItemsFromPosts } from "src/libs/utils/notion"
 
 export const useTagsQuery = () => {
   const posts = usePostsQuery()

--- a/src/layouts/RootLayout/Header/Logo.tsx
+++ b/src/layouts/RootLayout/Header/Logo.tsx
@@ -1,6 +1,7 @@
-import Link from "next/link"
-import { CONFIG } from "site.config"
 import styled from "@emotion/styled"
+import Link from "next/link"
+
+import { CONFIG } from "site.config"
 
 const Logo = () => {
   return (

--- a/src/layouts/RootLayout/Header/ThemeToggle.tsx
+++ b/src/layouts/RootLayout/Header/ThemeToggle.tsx
@@ -1,7 +1,8 @@
 import styled from "@emotion/styled"
 import React from "react"
-import { Emoji } from "src/components/Emoji"
-import useScheme from "src/hooks/useScheme"
+
+import { Emoji } from "@/components/Emoji"
+import useScheme from "@/hooks/useScheme"
 
 type Props = {}
 

--- a/src/layouts/RootLayout/Header/index.tsx
+++ b/src/layouts/RootLayout/Header/index.tsx
@@ -1,8 +1,10 @@
-import NavBar from "./NavBar"
-import Logo from "./Logo"
-import ThemeToggle from "./ThemeToggle"
 import styled from "@emotion/styled"
-import { zIndexes } from "src/styles/zIndexes"
+
+import { zIndexes } from "@/styles/zIndexes"
+
+import Logo from "./Logo"
+import NavBar from "./NavBar"
+import ThemeToggle from "./ThemeToggle"
 
 type Props = {
   fullWidth: boolean

--- a/src/layouts/RootLayout/Scripts.tsx
+++ b/src/layouts/RootLayout/Scripts.tsx
@@ -1,4 +1,5 @@
 import Script from "next/script"
+
 import { CONFIG } from "site.config"
 
 const Scripts: React.FC = () => (

--- a/src/layouts/RootLayout/ThemeProvider/Global/index.tsx
+++ b/src/layouts/RootLayout/ThemeProvider/Global/index.tsx
@@ -1,7 +1,11 @@
-import { Global as _Global, css, useTheme } from "@emotion/react"
+import {
+  Global as _Global,
+  ThemeProvider as _ThemeProvider,
+  css,
+  useTheme,
+} from "@emotion/react"
 
-import { ThemeProvider as _ThemeProvider } from "@emotion/react"
-import { pretendard } from "src/assets"
+import { pretendard } from "@/assets"
 
 export const Global = () => {
   const theme = useTheme()

--- a/src/layouts/RootLayout/ThemeProvider/index.tsx
+++ b/src/layouts/RootLayout/ThemeProvider/index.tsx
@@ -1,6 +1,8 @@
 import { ThemeProvider as _ThemeProvider } from "@emotion/react"
+
+import { createTheme } from "@/styles"
+
 import { Global } from "./Global"
-import { createTheme } from "src/styles"
 
 type Props = {
   scheme: string

--- a/src/layouts/RootLayout/index.tsx
+++ b/src/layouts/RootLayout/index.tsx
@@ -1,9 +1,11 @@
-import React, { ReactNode } from "react"
-import { ThemeProvider } from "./ThemeProvider"
-import useScheme from "src/hooks/useScheme"
-import Header from "./Header"
 import styled from "@emotion/styled"
-import Scripts from "src/layouts/RootLayout/Scripts"
+import { ReactNode } from "react"
+
+import useScheme from "@/hooks/useScheme"
+import Scripts from "@/layouts/RootLayout/Scripts"
+
+import Header from "./Header"
+import { ThemeProvider } from "./ThemeProvider"
 import useGtagEffect from "./useGtagEffect"
 
 type Props = {

--- a/src/layouts/RootLayout/useGtagEffect.ts
+++ b/src/layouts/RootLayout/useGtagEffect.ts
@@ -1,6 +1,7 @@
-import { useEffect } from "react"
 import { useRouter } from "next/router"
-import * as gtag from "src/libs/gtag"
+import { useEffect } from "react"
+
+import * as gtag from "@/libs/gtag"
 import { CONFIG } from "site.config"
 
 const useGtagEffect = () => {

--- a/src/libs/utils/notion/filterPosts.ts
+++ b/src/libs/utils/notion/filterPosts.ts
@@ -1,4 +1,4 @@
-import { TPosts, TPostStatus, TPostType } from "src/types"
+import { TPosts, TPostStatus, TPostType } from "@/types"
 
 export type FilterPostsOptions = {
   acceptStatus?: TPostStatus[]

--- a/src/libs/utils/notion/getAllPageIds.ts
+++ b/src/libs/utils/notion/getAllPageIds.ts
@@ -1,10 +1,7 @@
-import { idToUuid } from "notion-utils"
 import { ExtendedRecordMap, ID } from "notion-types"
+import { idToUuid } from "notion-utils"
 
-export default function getAllPageIds(
-  response: ExtendedRecordMap,
-  viewId?: string
-) {
+export function getAllPageIds(response: ExtendedRecordMap, viewId?: string) {
   const collectionQuery = response.collection_query
   const views = Object.values(collectionQuery)[0]
 

--- a/src/libs/utils/notion/getAllSelectItemsFromPosts.ts
+++ b/src/libs/utils/notion/getAllSelectItemsFromPosts.ts
@@ -1,4 +1,4 @@
-import { TPosts } from "src/types"
+import { TPosts } from "@/types"
 
 export function getAllSelectItemsFromPosts(
   key: "tags" | "category",

--- a/src/libs/utils/notion/getMetadata.ts
+++ b/src/libs/utils/notion/getMetadata.ts
@@ -1,4 +1,4 @@
-export default function getMetadata(rawMetadata: any) {
+export function getMetadata(rawMetadata: any) {
   const metadata = {
     locked: rawMetadata?.format?.block_locked,
     page_full_width: rawMetadata?.format?.page_full_width,

--- a/src/libs/utils/notion/getPageProperties.ts
+++ b/src/libs/utils/notion/getPageProperties.ts
@@ -1,9 +1,10 @@
-import { getTextContent, getDateValue } from "notion-utils"
 import { NotionAPI } from "notion-client"
 import { BlockMap, CollectionPropertySchemaMap } from "notion-types"
+import { getDateValue, getTextContent } from "notion-utils"
+
 import { customMapImageUrl } from "./customMapImageUrl"
 
-async function getPageProperties(
+export async function getPageProperties(
   id: string,
   block: BlockMap,
   schema: CollectionPropertySchemaMap
@@ -81,5 +82,3 @@ async function getPageProperties(
   }
   return properties
 }
-
-export { getPageProperties as default }

--- a/src/libs/utils/notion/index.ts
+++ b/src/libs/utils/notion/index.ts
@@ -1,2 +1,6 @@
+export { customMapImageUrl } from "./customMapImageUrl"
+export { getAllPageIds } from "./getAllPageIds"
 export { getAllSelectItemsFromPosts } from "./getAllSelectItemsFromPosts"
+export { getMetadata } from "./getMetadata"
+export { getPageProperties } from "./getPageProperties"
 export { filterPosts } from "./filterPosts"

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,7 +1,7 @@
-import { CONFIG } from "../../site.config"
-import { NextPageWithLayout, TPosts, TTags } from "../types"
-import CustomError from "../routes/Error"
-import MetaConfig from "src/components/MetaConfig"
+import MetaConfig from "@/components/MetaConfig"
+import CustomError from "@/routes/Error"
+import { NextPageWithLayout, TPosts, TTags } from "@/types"
+import { CONFIG } from "site.config"
 
 type Props = {
   tags: TTags

--- a/src/pages/[slug].tsx
+++ b/src/pages/[slug].tsx
@@ -1,16 +1,18 @@
-import Detail from "src/routes/Detail"
-import { filterPosts } from "src/libs/utils/notion"
-import { CONFIG } from "site.config"
-import { NextPageWithLayout } from "../types"
-import CustomError from "src/routes/Error"
-import { getRecordMap, getPosts } from "src/apis"
-import MetaConfig from "src/components/MetaConfig"
 import { GetStaticProps } from "next"
-import { queryClient } from "src/libs/react-query"
-import { queryKey } from "src/constants/queryKey"
+
 import { dehydrate } from "@tanstack/react-query"
-import usePostQuery from "src/hooks/usePostQuery"
-import { FilterPostsOptions } from "src/libs/utils/notion/filterPosts"
+
+import { getPosts, getRecordMap } from "@/apis"
+import MetaConfig from "@/components/MetaConfig"
+import { queryKey } from "@/constants/queryKey"
+import usePostQuery from "@/hooks/usePostQuery"
+import { queryClient } from "@/libs/react-query"
+import { filterPosts } from "@/libs/utils/notion"
+import { FilterPostsOptions } from "@/libs/utils/notion/filterPosts"
+import Detail from "@/routes/Detail"
+import CustomError from "@/routes/Error"
+import { NextPageWithLayout } from "@/types"
+import { CONFIG } from "site.config"
 
 const filter: FilterPostsOptions = {
   acceptStatus: ["Public", "PublicOnDetail"],

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,6 +2,7 @@ import { AppPropsWithLayout } from "../types"
 import { Hydrate, QueryClientProvider } from "@tanstack/react-query"
 import { RootLayout } from "src/layouts"
 import { queryClient } from "src/libs/react-query"
+import "src/styles/table.css"
 
 function App({ Component, pageProps }: AppPropsWithLayout) {
   const getLayout = Component.getLayout || ((page) => page)

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,8 +1,9 @@
-import { AppPropsWithLayout } from "../types"
 import { Hydrate, QueryClientProvider } from "@tanstack/react-query"
-import { RootLayout } from "src/layouts"
-import { queryClient } from "src/libs/react-query"
-import "src/styles/table.css"
+
+import { RootLayout } from "@/layouts"
+import { queryClient } from "@/libs/react-query"
+import { AppPropsWithLayout } from "@/types"
+import "@/styles/table.css"
 
 function App({ Component, pageProps }: AppPropsWithLayout) {
   const getLayout = Component.getLayout || ((page) => page)

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,4 +1,5 @@
-import Document, { Html, Head, Main, NextScript } from "next/document"
+import Document, { Head, Html, Main, NextScript } from "next/document"
+
 import { CONFIG } from "site.config"
 
 class MyDocument extends Document {

--- a/src/pages/api/revalidate.ts
+++ b/src/pages/api/revalidate.ts
@@ -1,4 +1,5 @@
 import { NextApiRequest, NextApiResponse } from "next"
+
 import { getPosts } from "../../apis"
 
 // for all path revalidate, https://<your-site.com>/api/revalidate?secret=<token>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,13 +1,15 @@
-import Feed from "src/routes/Feed"
-import { CONFIG } from "../../site.config"
-import { NextPageWithLayout } from "../types"
-import { getPosts } from "../apis"
-import MetaConfig from "src/components/MetaConfig"
-import { queryClient } from "src/libs/react-query"
-import { queryKey } from "src/constants/queryKey"
 import { GetStaticProps } from "next"
+
 import { dehydrate } from "@tanstack/react-query"
-import { filterPosts } from "src/libs/utils/notion"
+
+import { getPosts } from "@/apis"
+import MetaConfig from "@/components/MetaConfig"
+import { queryKey } from "@/constants/queryKey"
+import { queryClient } from "@/libs/react-query"
+import { filterPosts } from "@/libs/utils/notion"
+import Feed from "@/routes/Feed"
+import { NextPageWithLayout } from "@/types"
+import { CONFIG } from "site.config"
 
 export const getStaticProps: GetStaticProps = async () => {
   const posts = filterPosts(await getPosts())

--- a/src/routes/Detail/PageDetail/index.tsx
+++ b/src/routes/Detail/PageDetail/index.tsx
@@ -1,7 +1,9 @@
-import React from "react"
 import styled from "@emotion/styled"
-import NotionRenderer from "../components/NotionRenderer"
-import usePostQuery from "src/hooks/usePostQuery"
+import React from "react"
+
+import usePostQuery from "@/hooks/usePostQuery"
+import NotionRenderer from "@/routes/Detail/components/NotionRenderer"
+
 type Props = {}
 
 const PageDetail: React.FC<Props> = () => {

--- a/src/routes/Detail/PostDetail/CommentBox/Cusdis.tsx
+++ b/src/routes/Detail/PostDetail/CommentBox/Cusdis.tsx
@@ -1,9 +1,10 @@
-import { CONFIG } from "site.config"
-import { ReactCusdis } from "react-cusdis"
-import { useCallback, useEffect, useState } from "react"
 import styled from "@emotion/styled"
-import useScheme from "src/hooks/useScheme"
 import { useRouter } from "next/router"
+import { useCallback, useEffect, useState } from "react"
+import { ReactCusdis } from "react-cusdis"
+
+import useScheme from "@/hooks/useScheme"
+import { CONFIG } from "site.config"
 
 type Props = {
   id: string

--- a/src/routes/Detail/PostDetail/CommentBox/Utterances.tsx
+++ b/src/routes/Detail/PostDetail/CommentBox/Utterances.tsx
@@ -1,8 +1,9 @@
-import { CONFIG } from "site.config"
-import { useEffect } from "react"
 import styled from "@emotion/styled"
-import useScheme from "src/hooks/useScheme"
 import { useRouter } from "next/router"
+import { useEffect } from "react"
+
+import useScheme from "@/hooks/useScheme"
+import { CONFIG } from "site.config"
 
 //TODO: useRef?
 

--- a/src/routes/Detail/PostDetail/CommentBox/index.tsx
+++ b/src/routes/Detail/PostDetail/CommentBox/index.tsx
@@ -1,6 +1,7 @@
-import { TPost } from "src/types"
-import { CONFIG } from "site.config"
 import dynamic from "next/dynamic"
+
+import { TPost } from "@/types"
+import { CONFIG } from "site.config"
 
 const UtterancesComponent = dynamic(
   () => {

--- a/src/routes/Detail/PostDetail/PostHeader.tsx
+++ b/src/routes/Detail/PostDetail/PostHeader.tsx
@@ -1,10 +1,11 @@
-import { CONFIG } from "site.config"
-import Tag from "src/components/Tag"
-import { TPost } from "src/types"
-import { formatDate } from "src/libs/utils"
+import styled from "@emotion/styled"
 import Image from "next/image"
 import React from "react"
-import styled from "@emotion/styled"
+
+import Tag from "@/components/Tag"
+import { formatDate } from "@/libs/utils"
+import { TPost } from "@/types"
+import { CONFIG } from "site.config"
 
 type Props = {
   data: TPost

--- a/src/routes/Detail/PostDetail/index.tsx
+++ b/src/routes/Detail/PostDetail/index.tsx
@@ -1,11 +1,13 @@
-import React from "react"
-import PostHeader from "./PostHeader"
-import Footer from "./PostFooter"
-import CommentBox from "./CommentBox"
-import Category from "src/components/Category"
 import styled from "@emotion/styled"
-import NotionRenderer from "../components/NotionRenderer"
-import usePostQuery from "src/hooks/usePostQuery"
+import React from "react"
+
+import Category from "@/components/Category"
+import usePostQuery from "@/hooks/usePostQuery"
+import NotionRenderer from "@/routes/Detail/components/NotionRenderer"
+
+import CommentBox from "./CommentBox"
+import Footer from "./PostFooter"
+import PostHeader from "./PostHeader"
 
 type Props = {}
 

--- a/src/routes/Detail/components/NotionRenderer/index.tsx
+++ b/src/routes/Detail/components/NotionRenderer/index.tsx
@@ -1,11 +1,14 @@
+import styled from "@emotion/styled"
 import dynamic from "next/dynamic"
 import Image from "next/image"
 import Link from "next/link"
 import { ExtendedRecordMap } from "notion-types"
-import useScheme from "src/hooks/useScheme"
+import { FC } from "react"
+
+import useScheme from "@/hooks/useScheme"
 
 // core styles shared by all of react-notion-x (required)
-import "react-notion-x/src/styles.css"
+import "react-notion-x/@/styles.css"
 
 // used for code syntax highlighting (optional)
 import "prismjs/themes/prism-tomorrow.css"
@@ -13,8 +16,6 @@ import "prismjs/themes/prism-tomorrow.css"
 // used for rendering equations (optional)
 
 import "katex/dist/katex.min.css"
-import { FC } from "react"
-import styled from "@emotion/styled"
 
 const _NotionRenderer = dynamic(
   () => import("react-notion-x").then((m) => m.NotionRenderer),

--- a/src/routes/Detail/hooks/useMermaidEffect.ts
+++ b/src/routes/Detail/hooks/useMermaidEffect.ts
@@ -1,5 +1,5 @@
-import { useEffect } from "react"
 import mermaid from "mermaid"
+import { useEffect } from "react"
 
 const useMermaidEffect = () => {
   useEffect(() => {

--- a/src/routes/Detail/index.tsx
+++ b/src/routes/Detail/index.tsx
@@ -1,8 +1,10 @@
-import useMermaidEffect from "./hooks/useMermaidEffect"
-import PostDetail from "./PostDetail"
-import PageDetail from "./PageDetail"
 import styled from "@emotion/styled"
-import usePostQuery from "src/hooks/usePostQuery"
+
+import usePostQuery from "@/hooks/usePostQuery"
+import useMermaidEffect from "@/routes/Detail/hooks/useMermaidEffect"
+
+import PageDetail from "./PageDetail"
+import PostDetail from "./PostDetail"
 
 type Props = {}
 

--- a/src/routes/Error/index.tsx
+++ b/src/routes/Error/index.tsx
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled"
 import React from "react"
-import { Emoji } from "src/components/Emoji"
+
+import { Emoji } from "@/components/Emoji"
 
 type Props = {}
 

--- a/src/routes/Feed/ContactCard.tsx
+++ b/src/routes/Feed/ContactCard.tsx
@@ -1,12 +1,13 @@
-import { CONFIG } from "site.config"
+import styled from "@emotion/styled"
 import React from "react"
 import {
-  AiOutlineInstagram,
-  AiOutlineGithub,
-  AiOutlineMail,
   AiFillLinkedin,
+  AiOutlineGithub,
+  AiOutlineInstagram,
+  AiOutlineMail,
 } from "react-icons/ai"
-import styled from "@emotion/styled"
+
+import { CONFIG } from "site.config"
 
 const ContactCard: React.FC = () => {
   return (

--- a/src/routes/Feed/FeedHeader/CategorySelect.tsx
+++ b/src/routes/Feed/FeedHeader/CategorySelect.tsx
@@ -1,10 +1,11 @@
-import useDropdown from "src/hooks/useDropdown"
+import styled from "@emotion/styled"
 import { useRouter } from "next/router"
 import React from "react"
 import { MdExpandMore } from "react-icons/md"
-import { DEFAULT_CATEGORY } from "src/constants"
-import styled from "@emotion/styled"
-import { useCategoriesQuery } from "src/hooks/useCategoriesQuery"
+
+import { DEFAULT_CATEGORY } from "@/constants"
+import { useCategoriesQuery } from "@/hooks/useCategoriesQuery"
+import useDropdown from "@/hooks/useDropdown"
 
 type Props = {}
 

--- a/src/routes/Feed/FeedHeader/FeedHeader.tsx
+++ b/src/routes/Feed/FeedHeader/FeedHeader.tsx
@@ -1,8 +1,8 @@
-import { TCategories } from "src/types"
+import styled from "@emotion/styled"
 import React from "react"
+
 import CategorySelect from "./CategorySelect"
 import OrderButtons from "./OrderButtons"
-import styled from "@emotion/styled"
 
 type Props = {}
 

--- a/src/routes/Feed/Footer.tsx
+++ b/src/routes/Feed/Footer.tsx
@@ -1,6 +1,7 @@
-import { CONFIG } from "site.config"
-import React from "react"
 import styled from "@emotion/styled"
+import React from "react"
+
+import { CONFIG } from "site.config"
 
 const d = new Date()
 const y = d.getFullYear()

--- a/src/routes/Feed/MobileProfileCard.tsx
+++ b/src/routes/Feed/MobileProfileCard.tsx
@@ -1,7 +1,8 @@
-import { CONFIG } from "site.config"
+import styled from "@emotion/styled"
 import Image from "next/image"
 import React from "react"
-import styled from "@emotion/styled"
+
+import { CONFIG } from "site.config"
 
 type Props = {
   className?: string

--- a/src/routes/Feed/PostList/PostCard.tsx
+++ b/src/routes/Feed/PostList/PostCard.tsx
@@ -1,11 +1,12 @@
-import Link from "next/link"
-import { CONFIG } from "site.config"
-import { formatDate } from "src/libs/utils"
-import Tag from "../../../components/Tag"
-import { TPost } from "../../../types"
-import Image from "next/image"
-import Category from "../../../components/Category"
 import styled from "@emotion/styled"
+import Image from "next/image"
+import Link from "next/link"
+
+import Category from "@/components/Category"
+import Tag from "@/components/Tag"
+import { formatDate } from "@/libs/utils"
+import { TPost } from "@/types"
+import { CONFIG } from "site.config"
 
 type Props = {
   data: TPost

--- a/src/routes/Feed/PostList/index.tsx
+++ b/src/routes/Feed/PostList/index.tsx
@@ -1,8 +1,9 @@
 import { useRouter } from "next/router"
 import React, { useEffect, useState } from "react"
-import PostCard from "src/routes/Feed/PostList/PostCard"
-import { DEFAULT_CATEGORY } from "src/constants"
-import usePostsQuery from "src/hooks/usePostsQuery"
+
+import { DEFAULT_CATEGORY } from "@/constants"
+import usePostsQuery from "@/hooks/usePostsQuery"
+import PostCard from "@/routes/Feed/PostList/PostCard"
 
 type Props = {
   q: string

--- a/src/routes/Feed/ProfileCard.tsx
+++ b/src/routes/Feed/ProfileCard.tsx
@@ -1,8 +1,9 @@
-import { CONFIG } from "site.config"
+import styled from "@emotion/styled"
 import Image from "next/image"
 import React from "react"
-import styled from "@emotion/styled"
-import { Emoji } from "src/components/Emoji"
+
+import { Emoji } from "@/components/Emoji"
+import { CONFIG } from "site.config"
 
 type Props = {}
 

--- a/src/routes/Feed/SearchInput.tsx
+++ b/src/routes/Feed/SearchInput.tsx
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled"
-import React, { InputHTMLAttributes, ReactNode } from "react"
-import { Emoji } from "src/components/Emoji"
+import React, { InputHTMLAttributes } from "react"
+
+import { Emoji } from "@/components/Emoji"
 
 interface Props extends InputHTMLAttributes<HTMLInputElement> {}
 

--- a/src/routes/Feed/ServiceCard.tsx
+++ b/src/routes/Feed/ServiceCard.tsx
@@ -1,8 +1,9 @@
-import { CONFIG } from "site.config"
+import styled from "@emotion/styled"
 import React from "react"
 import { AiFillCodeSandboxCircle } from "react-icons/ai"
-import styled from "@emotion/styled"
-import { Emoji } from "src/components/Emoji"
+
+import { Emoji } from "@/components/Emoji"
+import { CONFIG } from "site.config"
 
 const ServiceCard: React.FC = () => {
   if (!CONFIG.projects) return null

--- a/src/routes/Feed/TagList.tsx
+++ b/src/routes/Feed/TagList.tsx
@@ -1,8 +1,9 @@
 import styled from "@emotion/styled"
 import { useRouter } from "next/router"
 import React from "react"
-import { Emoji } from "src/components/Emoji"
-import { useTagsQuery } from "src/hooks/useTagsQuery"
+
+import { Emoji } from "@/components/Emoji"
+import { useTagsQuery } from "@/hooks/useTagsQuery"
 
 type Props = {}
 

--- a/src/routes/Feed/index.tsx
+++ b/src/routes/Feed/index.tsx
@@ -1,15 +1,15 @@
+import styled from "@emotion/styled"
 import { useState } from "react"
 
-import SearchInput from "./SearchInput"
+import ContactCard from "./ContactCard"
 import { FeedHeader } from "./FeedHeader"
 import Footer from "./Footer"
-import styled from "@emotion/styled"
-import TagList from "./TagList"
 import MobileProfileCard from "./MobileProfileCard"
-import ProfileCard from "./ProfileCard"
-import ServiceCard from "./ServiceCard"
-import ContactCard from "./ContactCard"
 import PostList from "./PostList"
+import ProfileCard from "./ProfileCard"
+import SearchInput from "./SearchInput"
+import ServiceCard from "./ServiceCard"
+import TagList from "./TagList"
 
 const HEADER_HEIGHT = 73
 

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -1,14 +1,14 @@
 import {
-  gray,
   blue,
-  red,
-  green,
-  grayDark,
   blueDark,
-  redDark,
+  gray,
+  grayDark,
+  green,
   greenDark,
   indigo,
   indigoDark,
+  red,
+  redDark,
 } from "@radix-ui/colors"
 
 export type Colors = typeof colors.light & typeof colors.dark

--- a/src/styles/media.ts
+++ b/src/styles/media.ts
@@ -1,3 +1,3 @@
-import { variables } from './variables'
+import { variables } from "./variables"
 
 export const respondMobile = `@media (max-width: ${variables.breakpoint}px)`

--- a/src/styles/table.css
+++ b/src/styles/table.css
@@ -1,0 +1,44 @@
+.notion-table-of-contents {
+  position: fixed;
+  right: -75%;
+  top: 80px;
+  display: flex;
+  flex-direction: column;
+}
+
+@media screen and (max-width: 1800px) {
+  .notion-table-of-contents {
+    right: -80%;
+  }
+}
+
+@media screen and (max-width: 1500px) {
+  .notion-table-of-contents {
+    position: static;
+  }
+}
+
+.notion-table-of-contents a {
+  padding: 0;
+  margin-bottom: 10px;
+}
+
+.notion-table-of-contents a:hover {
+  background: none;
+}
+
+.notion-table-of-contents span {
+  padding: 2px 2px;
+  line-height: 1.3;
+  background: linear-gradient(
+    to right,
+    rgba(255, 255, 255, 0) 50%,
+    var(--bg-color-0) 50%
+  );
+  background-size: 200%;
+  transition: 0.35s;
+}
+
+.notion-table-of-contents span:hover {
+  background-position: -100% 0;
+}

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,4 +1,5 @@
 import { Theme } from "@emotion/react"
+
 import { Colors, colors } from "./colors"
 import { variables } from "./variables"
 import { zIndexes } from "./zIndexes"

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 import { NextPage } from "next"
+
 import { AppProps } from "next/app"
 import { ExtendedRecordMap } from "notion-types"
 import { ReactElement, ReactNode } from "react"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,10 @@
     "jsx": "preserve",
     "jsxImportSource": "@emotion/react",
     "incremental": true,
-    "baseUrl": "."
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "site.config.js"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Description

While looking at the code, I saw that the relative path and order were not organized in the import code.

So we added a function to organize the order. The following changes were made to add this function:
1. Add path attribute to tsconfig file to prevent `src/` path from being overused.  
`src/components` -> `@/components`
2. Add `rules` to `.eslintrc.json` for organize import order

before
<img width="519" alt="스크린샷 2023-11-06 오후 4 19 29" src="https://github.com/morethanmin/morethan-log/assets/80191860/8171a1d2-86f8-4a2c-93c2-c71278b6a4db">

after
<img width="585" alt="스크린샷 2023-11-06 오후 4 19 47" src="https://github.com/morethanmin/morethan-log/assets/80191860/db362c72-a5e9-45ad-b46c-ed7242a2b067">

You may be reluctant to merge because there are a lot of file changes, but the following problems can be improved with these changes:
- Unification of code styles of multiple contributors
- Replace relative paths with path aliases -> 
Match code style even when file path changes

It is for this benefit that I request the change.

## PR Checklist

- [ ] I have read the [Contributing Guide](./docs/CONTRIBUTING.md)
- [ ] I have written documents and tests, if needed.
