### PR TITLE
Fix: Fixing issue 309, which code block doesn't load all the time

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,2 @@
 declare module 'prismjs/components/prism-*.js';
+declare module 'prismjs/prism';

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "notion-client": "^6.16.0",
     "notion-types": "^6.16.0",
     "notion-utils": "^6.16.0",
+    "prismjs": "^1.29.0",
     "react": "^18.2.0",
     "react-cusdis": "^2.1.3",
     "react-dom": "^18.2.0",
@@ -42,6 +43,7 @@
     "next-sitemap": "^3.1.32",
     "postcss": "^8.3.11",
     "prettier": "^2.7.1",
+    "prismjs": "^1.29.0",
     "typescript": "^4.9.4"
   }
 }

--- a/src/layouts/RootLayout/index.tsx
+++ b/src/layouts/RootLayout/index.tsx
@@ -1,10 +1,44 @@
-import React, { ReactNode } from "react"
+import React, { ReactNode, useEffect } from "react"
 import { ThemeProvider } from "./ThemeProvider"
 import useScheme from "src/hooks/useScheme"
 import Header from "./Header"
 import styled from "@emotion/styled"
 import Scripts from "src/layouts/RootLayout/Scripts"
 import useGtagEffect from "./useGtagEffect"
+import Prism from "prismjs/prism"
+import 'prismjs/components/prism-markup-templating.js'
+import 'prismjs/components/prism-markup.js'
+import 'prismjs/components/prism-bash.js'
+import 'prismjs/components/prism-c.js'
+import 'prismjs/components/prism-cpp.js'
+import 'prismjs/components/prism-csharp.js'
+import 'prismjs/components/prism-docker.js'
+import 'prismjs/components/prism-java.js'
+import 'prismjs/components/prism-js-templates.js'
+import 'prismjs/components/prism-coffeescript.js'
+import 'prismjs/components/prism-diff.js'
+import 'prismjs/components/prism-git.js'
+import 'prismjs/components/prism-go.js'
+import 'prismjs/components/prism-kotlin.js'
+import 'prismjs/components/prism-graphql.js'
+import 'prismjs/components/prism-handlebars.js'
+import 'prismjs/components/prism-less.js'
+import 'prismjs/components/prism-makefile.js'
+import 'prismjs/components/prism-markdown.js'
+import 'prismjs/components/prism-objectivec.js'
+import 'prismjs/components/prism-ocaml.js'
+import 'prismjs/components/prism-python.js'
+import 'prismjs/components/prism-reason.js'
+import 'prismjs/components/prism-rust.js'
+import 'prismjs/components/prism-sass.js'
+import 'prismjs/components/prism-scss.js'
+import 'prismjs/components/prism-solidity.js'
+import 'prismjs/components/prism-sql.js'
+import 'prismjs/components/prism-stylus.js'
+import 'prismjs/components/prism-swift.js'
+import 'prismjs/components/prism-wasm.js'
+import 'prismjs/components/prism-yaml.js'
+import "prismjs/components/prism-go.js"
 
 type Props = {
   children: ReactNode
@@ -13,6 +47,10 @@ type Props = {
 const RootLayout = ({ children }: Props) => {
   const [scheme] = useScheme()
   useGtagEffect()
+  useEffect(() => {
+    Prism.highlightAll();
+  }, []);
+
   return (
     <ThemeProvider scheme={scheme}>
       <Scripts />

--- a/src/routes/Detail/components/NotionRenderer/index.tsx
+++ b/src/routes/Detail/components/NotionRenderer/index.tsx
@@ -22,42 +22,7 @@ const _NotionRenderer = dynamic(
 )
 
 const Code = dynamic(() =>
-  import("react-notion-x/build/third-party/code").then(async (m) => {
-    await Promise.all([
-      import("prismjs/components/prism-markup-templating.js"),
-      import("prismjs/components/prism-markup.js"),
-      import("prismjs/components/prism-bash.js"),
-      import("prismjs/components/prism-c.js"),
-      import("prismjs/components/prism-cpp.js"),
-      import("prismjs/components/prism-csharp.js"),
-      import("prismjs/components/prism-docker.js"),
-      import("prismjs/components/prism-java.js"),
-      import("prismjs/components/prism-js-templates.js"),
-      import("prismjs/components/prism-coffeescript.js"),
-      import("prismjs/components/prism-diff.js"),
-      import("prismjs/components/prism-git.js"),
-      import("prismjs/components/prism-go.js"),
-      import("prismjs/components/prism-graphql.js"),
-      import("prismjs/components/prism-handlebars.js"),
-      import("prismjs/components/prism-less.js"),
-      import("prismjs/components/prism-makefile.js"),
-      import("prismjs/components/prism-markdown.js"),
-      import("prismjs/components/prism-objectivec.js"),
-      import("prismjs/components/prism-ocaml.js"),
-      import("prismjs/components/prism-python.js"),
-      import("prismjs/components/prism-reason.js"),
-      import("prismjs/components/prism-rust.js"),
-      import("prismjs/components/prism-sass.js"),
-      import("prismjs/components/prism-scss.js"),
-      import("prismjs/components/prism-solidity.js"),
-      import("prismjs/components/prism-sql.js"),
-      import("prismjs/components/prism-stylus.js"),
-      import("prismjs/components/prism-swift.js"),
-      import("prismjs/components/prism-wasm.js"),
-      import("prismjs/components/prism-yaml.js"),
-    ])
-    return m.Code
-  })
+  import("react-notion-x/build/third-party/code").then(async (m) =>  m.Code )
 )
 
 const Collection = dynamic(() =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3135,7 +3135,7 @@ prettier@^2.7.1:
   resolved "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz"
   integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
 
-prismjs@^1.27.0:
+prismjs@^1.27.0, prismjs@^1.29.0:
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.29.0.tgz#f113555a8fa9b57c35e637bba27509dcf802dd12"
   integrity sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==


### PR DESCRIPTION
# Fix: Fixing issue 309, which code block doesn't load all the time

## Description
Note: Since I'm not a frontend dev and doesn't work with frontend and react there are many years, I might say that something maybe will be incorrect, so, be kind and tell me that I will solve.

Once you reload, the next times the code will be loaded.

### Problem

When using the morethan-log I saw that sometimes code blocks are loaded and sometimes it wasn't loaded, and found the #309 issue warning about this started to try solve it.

I also saw that the problem doesn't occur in dev environment, but only when you run: 

```bash
next build
next start
```

and in prod when you acces for the first time, to test, you can open some private windows and try access the site: https://morethan-log.vercel.app/apollo-gettings-started-mutate sometimes

### Debug approach

First stuff I done was removing the prismjs imports in the notion renderer components to understand if it would work without them. So, they worked and I discovered the origin of the problem.

After this I was thinking for some days about could be happening and decided to try import the highlights out of the promise, I was thinking that the amount of JS files being loaded could be making the highlight lazy since when I was debugging the code appear first without highlight and right after in next breakpoint it disappear.

### Solution
So I moved the imports to the root layout, installed prismjs (I previously checked it it was in the `package.json` and it wasn't there) and imported it according some internet tutorials.

After all, I used prism to code:

```js
  useEffect(() => {
    Prism.highlightAll();
  }, []);
 ```
  
 And doing this, It was working all time, so if you can test and assure it, I would be very grateful.

## Related tickets

https://github.com/morethanmin/morethan-log/issues/309


## PR Checklist

- [x] I have read the [Contributing Guide](./docs/CONTRIBUTING.md)
- [x] I have written documents and tests, if needed.
