### PR TITLE
[fix] update padding of postcard

### DIFF
--- a/src/routes/Feed/PostList/PostCard.tsx
+++ b/src/routes/Feed/PostList/PostCard.tsx
@@ -32,7 +32,7 @@ const PostCard: React.FC<Props> = ({ data }) => {
             />
           </div>
         )}
-        <div data-thumb={!!data.thumbnail} className="content">
+        <div data-thumb={!!data.thumbnail} data-category={!!category} className="content">
           <header className="top">
             <h2>{data.title}</h2>
           </header>
@@ -103,6 +103,9 @@ const StyledWrapper = styled(Link)`
 
       &[data-thumb="false"] {
         padding-top: 3.5rem;
+      }
+      &[data-category="false"] {
+        padding-top: 1.5rem;
       }
       > .top {
         display: flex;


### PR DESCRIPTION
<!-- 1. Verify PR Title -->
<!-- PR Title example: `[fix | refactor | feat | update | documentation]: repair the page layout` -->

<!-- 2. Provide Description of the changes -->

## Description
<!--
- provide a description of the changes made. If there are some pending TODOs, include them there as well.
- Any guidance for reviewers to better understand the changes.
- Any visuals (screenshots, screen recordings) that can give assurance that the changes are safe to merge.
-->
Update top-padding of postcard that doesn't have any categories.

### AS-IS
<img width="659" alt="스크린샷 2024-01-27 오후 8 42 48" src="https://github.com/morethanmin/morethan-log/assets/112816215/6fd7be03-f362-4dc0-bba5-44e58ac731b3">
<img width="659" alt="스크린샷 2024-01-27 오후 8 43 21" src="https://github.com/morethanmin/morethan-log/assets/112816215/b7663196-96a2-4d83-bd0a-1e8eef480e11">

The postcards have the same top-padding, whether there are categories or not.

### TO-BE
<img width="659" alt="스크린샷 2024-01-27 오후 8 49 18" src="https://github.com/morethanmin/morethan-log/assets/112816215/3fbf64d2-e28b-4212-a4f3-00e216ed9a27">

So, I reduced the top-padding when there are no categories.


<!-- 3. Add link to the Github Issue for which these changes are made -->

## Related tickets

https://github.com/morethanmin/morethan-log/issues/330

<!-- 4. Make sure the following actions are checked before finalising your PR -->

## PR Checklist

- [x] I have read the [Contributing Guide](./docs/CONTRIBUTING.md)
- [x] I have written documents and tests, if needed.
