### PR TITLE
feat : if slug is empty, use id

### DIFF
--- a/src/libs/utils/notion/filterPosts.ts
+++ b/src/libs/utils/notion/filterPosts.ts
@@ -23,7 +23,7 @@ export function filterPosts(
     // filter data
     .filter((post) => {
       const postDate = new Date(post?.date?.start_date || post.createdTime)
-      if (!post.title || !post.slug || postDate > tomorrow) return false
+      if (!post.title || postDate > tomorrow) return false
       return true
     })
     // filter status
@@ -35,6 +35,10 @@ export function filterPosts(
     .filter((post) => {
       const postType = post.type[0]
       return acceptType.includes(postType)
+    })
+    .map((post) => {
+      if (!post.slug) post.slug = post.id;
+      return post;
     })
   return filteredPosts
 }


### PR DESCRIPTION
<!-- 1. Verify PR Title -->
<!-- PR Title example: `[fix | refactor | feat | update | documentation]: repair the page layout` -->

<!-- 2. Provide Description of the changes -->

## Description
### What I Did
- Identified an issue where the slug value was empty in certain blog posts.
- Implemented a fallback mechanism where, if the slug is missing, the post's ID is used instead.

### Proposal
- Problem: The current implementation of the blog relies heavily on slug values for operations. However, in cases where the slug is absent, this could lead to unforeseen errors or dysfunctional behavior.
- Solution: My proposal is to modify the logic so that in the absence of a slug value, the system gracefully falls back to using the post's unique ID. This ensures continuity of functionality and enhances the robustness of the system.

<!--
- provide a description of the changes made. If there are some pending TODOs, include them there as well.
- Any guidance for reviewers to better understand the changes.
- Any visuals (screenshots, screen recordings) that can give assurance that the changes are safe to merge.
-->

<!-- 3. Add link to the Github Issue for which these changes are made -->

## Related tickets

https://github.com/morethanmin/morethan-log/issues/XX

<!-- 4. Make sure the following actions are checked before finalising your PR -->

## PR Checklist

- [x] I have read the [Contributing Guide](./docs/CONTRIBUTING.md)
- [x] I have written documents and tests, if needed.
