### PR TITLE
[fix]: ServiceCard rendering issue with project name in map function

### DIFF
--- a/src/routes/Feed/ServiceCard.tsx
+++ b/src/routes/Feed/ServiceCard.tsx
@@ -20,7 +20,7 @@ const ServiceCard: React.FC = () => {
             target="_blank"
           >
             <AiFillCodeSandboxCircle className="icon" />
-            <div className="name">{CONFIG.projects[0].name}</div>
+            <div className="name">{project.name}</div>
           </a>
         ))}
       </StyledWrapper>


### PR DESCRIPTION
<!-- 1. Verify PR Title -->
<!-- PR Title example: `[fix | refactor | feat | update | documentation]: repair the page layout` -->

<!-- 2. Provide Description of the changes -->

## Description

<!--
- provide a description of the changes made. If there are some pending TODOs, include them there as well.
- Any guidance for reviewers to better understand the changes.
- Any visuals (screenshots, screen recordings) that can give assurance that the changes are safe to merge.
-->

Fix code that was only getting the name of the first project when rendering the names of projects in the `ServiceCard`.

**Before)**
![image](https://github.com/morethanmin/morethan-log/assets/92802207/aca9df6c-9d3a-4bc6-bbfd-08f4393c7ecc)

**After)**
![image](https://github.com/morethanmin/morethan-log/assets/92802207/baff18e8-ef95-423d-aad4-38a760144407)


<!-- 3. Add link to the Github Issue for which these changes are made -->

## Related tickets

close: https://github.com/morethanmin/morethan-log/issues/324

<!-- 4. Make sure the following actions are checked before finalising your PR -->

## PR Checklist

- [x] I have read the [Contributing Guide](./docs/CONTRIBUTING.md)
- [x] I have written documents and tests, if needed.
