### PR TITLE
fix: 목록 타입의 블록이 콘텐츠 너비를 벗어나지 않도록 수정

### DIFF
--- a/src/routes/Detail/components/NotionRenderer/index.tsx
+++ b/src/routes/Detail/components/NotionRenderer/index.tsx
@@ -22,7 +22,7 @@ const _NotionRenderer = dynamic(
 )
 
 const Code = dynamic(() =>
-  import("react-notion-x/build/third-party/code").then(async (m) =>  m.Code )
+  import("react-notion-x/build/third-party/code").then(async (m) => m.Code)
 )
 
 const Collection = dynamic(() =>
@@ -85,5 +85,8 @@ const StyledWrapper = styled.div`
   }
   .notion-page {
     padding: 0;
+  }
+  .notion-list {
+    width: 100%;
   }
 `


### PR DESCRIPTION
<!-- 1. Verify PR Title -->
<!-- PR Title example: `[fix | refactor | feat | update | documentation]: repair the page layout` -->

<!-- 2. Provide Description of the changes -->

## Description
![스크린샷 2024-07-12 오후 11 57 31](https://github.com/user-attachments/assets/d88fc456-41fa-4387-94ff-69e07e9b7899)
목록 형태로 들여쓰기된 영역의 너비가 게시글 콘텐츠의 너비를 벗어나서 반응형에 문제가 발생했습니다.

![스크린샷 2024-07-12 오후 11 59 05](https://github.com/user-attachments/assets/755702d5-42fe-434c-975d-acc074939a00)
`.notion-list` 클래스에 대해 `width:100%`를 적용하여 수정했습니다.

<!--
- provide a description of the changes made. If there are some pending TODOs, include them there as well.
- Any guidance for reviewers to better understand the changes.
- Any visuals (screenshots, screen recordings) that can give assurance that the changes are safe to merge.
-->

<!-- 4. Make sure the following actions are checked before finalising your PR -->

## PR Checklist

- [x] I have read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I have written documents and tests, if needed.
