### PR TITLE
fix: handle Notion API's nested response format change

### DIFF
--- a/src/apis/notion-client/getPosts.ts
+++ b/src/apis/notion-client/getPosts.ts
@@ -17,11 +17,13 @@ export const getPosts = async () => {
 
   const response = await api.getPage(id)
   id = idToUuid(id)
-  const collection = Object.values(response.collection)[0]?.value
+  const collectionValue = Object.values(response.collection)[0]?.value as any
+  const collection = collectionValue?.value ?? collectionValue
   const block = response.block
   const schema = collection?.schema
 
-  const rawMetadata = block[id].value
+  const blockValue = (block[id].value as any)?.value ?? block[id].value
+  const rawMetadata = blockValue
 
   // Check Type
   if (
@@ -37,11 +39,12 @@ export const getPosts = async () => {
       const id = pageIds[i]
       const properties = (await getPageProperties(id, block, schema)) || null
       // Add fullwidth, createdtime to properties
+      const pageBlockValue = (block[id].value as any)?.value ?? block[id].value
       properties.createdTime = new Date(
-        block[id].value?.created_time
+        pageBlockValue?.created_time
       ).toString()
       properties.fullWidth =
-        (block[id].value?.format as any)?.page_full_width ?? false
+        (pageBlockValue?.format as any)?.page_full_width ?? false
 
       data.push(properties)
     }

--- a/src/libs/utils/notion/getPageProperties.ts
+++ b/src/libs/utils/notion/getPageProperties.ts
@@ -9,7 +9,9 @@ async function getPageProperties(
   schema: CollectionPropertySchemaMap
 ) {
   const api = new NotionAPI()
-  const rawProperties = Object.entries(block?.[id]?.value?.properties || [])
+  const blockEntry = block?.[id]?.value as any
+  const blockValue = blockEntry?.value ?? blockEntry
+  const rawProperties = Object.entries(blockValue?.properties || [])
   const excludeProperties = ["date", "select", "multi_select", "person", "file"]
   const properties: any = {}
   for (let i = 0; i < rawProperties.length; i++) {
@@ -21,7 +23,7 @@ async function getPageProperties(
       switch (schema[key]?.type) {
         case "file": {
           try {
-            const Block = block?.[id].value
+            const Block = blockValue
             const url: string = val[0][1][0][1]
             const newurl = customMapImageUrl(url, Block)
             properties[schema[key].name] = newurl


### PR DESCRIPTION
## Description

Fixes an issue where the main page shows "Nothing!" with 0 tags due to a change in the Notion API response format.

### Problem

The Notion API response structure for `block` and `collection` has changed:

- **Before**: `block[id].value` → block data directly (`{ type, properties, created_time, ... }`)
- **After**: `block[id].value` → `{ value: { type, properties, created_time, ... }, role: ... }`

This causes `rawMetadata.type` in `getPosts()` to be `undefined`, failing the type check and returning an empty array `[]`.

### Solution

Uses `?.value ?? fallback` pattern to support both the old and new response formats.

- `src/apis/notion-client/getPosts.ts`: Unwrap nested `collection` and `block` values
- `src/libs/utils/notion/getPageProperties.ts`: Unwrap nested block value

## Related tickets

https://github.com/morethanmin/morethan-log/issues/425

## PR Checklist

- [x] I have read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I have written documents and tests, if needed.