### PR TITLE
[fix]: support Notion uploaded video/audio playback and fix heading background color width

### DIFF
--- a/src/apis/notion-client/getRecordMap.ts
+++ b/src/apis/notion-client/getRecordMap.ts
@@ -1,7 +1,24 @@
 import { NotionAPI } from "notion-client"
+import { getPageContentBlockIds } from "notion-utils"
 
 export const getRecordMap = async (pageId: string) => {
   const api = new NotionAPI()
   const recordMap = await api.getPage(pageId)
+
+  // notion-client skips "attachment:uuid:filename" URLs when signing.
+  // For video/audio blocks these URLs are used directly by the browser,
+  // so replace them with a proxy URL that fetches a fresh signed URL on each request.
+  const blockIds = getPageContentBlockIds(recordMap)
+  blockIds.forEach((id) => {
+    const block = recordMap.block[id]?.value
+    if (!block || !["video", "audio"].includes(block.type)) return
+    if (recordMap.signed_urls[id]) return // already signed by notion-client
+
+    const source = block.properties?.source?.[0]?.[0]
+    if (!source || !source.startsWith("attachment:")) return
+
+    recordMap.signed_urls[id] = `/api/notion-file?blockId=${id}&url=${encodeURIComponent(source)}`
+  })
+
   return recordMap
 }

--- a/src/pages/api/notion-file.ts
+++ b/src/pages/api/notion-file.ts
@@ -1,0 +1,39 @@
+import { NextApiRequest, NextApiResponse } from "next"
+import { NotionAPI } from "notion-client"
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const { blockId, url } = req.query
+
+  if (
+    !blockId ||
+    typeof blockId !== "string" ||
+    !url ||
+    typeof url !== "string"
+  ) {
+    return res.status(400).json({ error: "Missing blockId or url" })
+  }
+
+  try {
+    const api = new NotionAPI()
+    const { signedUrls } = await api.getSignedFileUrls([
+      {
+        permissionRecord: {
+          table: "block",
+          id: blockId,
+        },
+        url,
+      },
+    ])
+
+    if (signedUrls?.[0]) {
+      res.redirect(307, signedUrls[0])
+    } else {
+      res.status(500).json({ error: "Failed to get signed URL" })
+    }
+  } catch {
+    res.status(500).json({ error: "Internal server error" })
+  }
+}

--- a/src/routes/Detail/components/NotionRenderer/index.tsx
+++ b/src/routes/Detail/components/NotionRenderer/index.tsx
@@ -12,9 +12,9 @@ import "prismjs/themes/prism-tomorrow.css"
 
 // used for rendering equations (optional)
 
+import styled from "@emotion/styled"
 import "katex/dist/katex.min.css"
 import { FC } from "react"
-import styled from "@emotion/styled"
 
 const _NotionRenderer = dynamic(
   () => import("react-notion-x").then((m) => m.NotionRenderer),
@@ -88,5 +88,15 @@ const StyledWrapper = styled.div`
   }
   .notion-list {
     width: 100%;
+  }
+  .notion-asset-wrapper-video {
+    max-width: 100%;
+  }
+  .notion-asset-wrapper-video > div {
+    height: auto !important;
+  }
+  .notion-asset-wrapper video {
+    max-width: 100%;
+    height: auto;
   }
 `

--- a/src/routes/Detail/components/NotionRenderer/index.tsx
+++ b/src/routes/Detail/components/NotionRenderer/index.tsx
@@ -99,4 +99,8 @@ const StyledWrapper = styled.div`
     max-width: 100%;
     height: auto;
   }
+  .notion-h {
+    display: block;
+    width: 100%;
+  }
 `

--- a/src/routes/Feed/ProfileCard.tsx
+++ b/src/routes/Feed/ProfileCard.tsx
@@ -17,9 +17,9 @@ const ProfileCard: React.FC<Props> = () => {
           <Image src={CONFIG.profile.image} fill alt="" />
         </div>
         <div className="mid">
-          <div className=" name">{CONFIG.profile.name}</div>
+          <div className="name">{CONFIG.profile.name}</div>
           <div className="role">{CONFIG.profile.role}</div>
-          <div className="text-sm mb-2">{CONFIG.profile.bio}</div>
+          <div className="bio">{CONFIG.profile.bio}</div>
         </div>
       </div>
     </StyledWrapper>
@@ -59,6 +59,7 @@ const StyledWrapper = styled.div`
       padding: 0.5rem;
       flex-direction: column;
       align-items: center;
+      text-align: center;
       .name {
         font-size: 1.25rem;
         line-height: 1.75rem;
@@ -72,8 +73,7 @@ const StyledWrapper = styled.div`
         color: ${({ theme }) => theme.colors.gray11};
       }
       .bio {
-        margin-bottom: 0.5rem;
-        font-size: 0.875rem;
+        font-size: 1rem;
         line-height: 1.25rem;
       }
     }


### PR DESCRIPTION
<!-- 1. Verify PR Title -->
<!-- PR Title example: `[fix | refactor | feat | update | documentation]: repair the page layout` -->

## Description
**1. Notion uploaded video/audio playback (closes #405)**

`notion-client`'s `addSignedUrls` skips `attachment:uuid:filename` format URLs, which Notion uses for directly uploaded files. As a result, the browser receives an unsigned URL it cannot load.

- Added `/api/notion-file` proxy route that calls `getSignedFileUrls` on each request to get a fresh signed URL
- In `getRecordMap`, for video/audio blocks with `attachment:` source URLs that were skipped by `notion-client`, the proxy URL is injected into `signed_urls` so react-notion-x can render them correctly

|Before|After|
|------|---|
|<img width="1598" height="1058" alt="image" src="https://github.com/user-attachments/assets/b2fcd193-bfbe-4d8c-9457-2eac37d350d0" />|![video-audio-fix](https://github.com/user-attachments/assets/75b73fd8-199b-4e8b-9887-b446de01afc0)|

**2. Heading block background color spans full width (closes #412)**

react-notion-x applies `display: inline-block` to `.notion-h`, and the parent container uses `align-items: flex-start`, causing heading elements to only stretch to text width. Block background colors appeared clipped to the text area.

- Overrode with `display: block; width: 100%` on `.notion-h`

|Before|After|
|------|---|
|<img width="1594" height="470" alt="image" src="https://github.com/user-attachments/assets/58abb0e7-d30f-4073-8a1f-6dce716a0f61" />|<img width="1524" height="418" alt="image" src="https://github.com/user-attachments/assets/146f084e-442e-44bc-8b96-823ed893dfdc" />|

**3. ProfileCard text center alignment (closes #161)**

Multi-line text in the ProfileCard was not centering properly on desktop.

- Added `text-align: center` to the card's flex column container


|Before|After|
|------|---|
|<img width="280" height="429" alt="image" src="https://github.com/user-attachments/assets/357e9e45-4e18-4fa2-966c-3dca91fde986" />|<img width="286" height="433" alt="image" src="https://github.com/user-attachments/assets/085db647-a86a-4d95-8c41-cc5547634ddd" />|



## Related tickets

https://github.com/morethanmin/morethan-log/issues/161
https://github.com/morethanmin/morethan-log/issues/405
https://github.com/morethanmin/morethan-log/issues/412

<!-- 4. Make sure the following actions are checked before finalising your PR -->

## PR Checklist

- [x] I have read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I have written documents and tests, if needed.
